### PR TITLE
Add extractdir command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,14 @@
+OS := $(shell uname)
+ifeq ($(OS),Darwin)
+	CXX=clang++
+	CC=clang
+else
+	CXX=g++
+	CC=gcc
+endif
+
 BIN=fatboy
-CXX=clang++
-CC=clang
+
 SRCS=$(wildcard *.c) elmchan/src/ff.c elmchan/src/diskio.c elmchan/src/option/unicode.c
 OBJS=$(patsubst %.c,%.o,$(SRCS))
 CFLAGS=-g -O3 --std=c11 -MP -MMD

--- a/Readme.md
+++ b/Readme.md
@@ -11,6 +11,7 @@ FatBoy supports the following actions:
  - ls
  - add
  - extract
+ - extractdir
  - rm
  - info
  - setlabel

--- a/fatboy.c
+++ b/fatboy.c
@@ -362,8 +362,13 @@ int main(int argc, const char *argv[]) {
 			char host_fname[4096];
 			for (;;) {
 				res = f_readdir(&dir, &fno);
-				if (res != FR_OK || fno.fname[0] == 0 || fno.fattrib & AM_DIR) {
+
+				if (res != FR_OK || fno.fname[0] == 0) {
 					break;  // Break on error or end of dir
+				}
+
+				if (fno.fattrib & AM_DIR) {
+					continue; // Ignore directories
 				}
 
 				strncpy(img_fname, img_path, sizeof img_path);

--- a/util.c
+++ b/util.c
@@ -1,0 +1,33 @@
+#include <stdlib.h>
+#include <string.h>
+
+#include "elmchan_impl.h"
+#include "elmchan/src/diskio.h"
+#include "elmchan/src/ff.h"
+
+#include "util.h"
+
+int write_file(FIL *image_fp, FILE *host_file)
+{
+	char buffer[4096];
+	int exit_code = 0;
+	int res;
+
+	uint32_t bytes_read, bytes_wrote;
+
+	for (;;) {
+		res = f_read(image_fp, buffer, sizeof buffer, &bytes_read);
+		if (res != RES_OK || bytes_read == 0) {
+			break;
+		}
+
+		bytes_wrote = fwrite(buffer, 1, bytes_read, host_file);
+		if (bytes_wrote < bytes_read) {
+			printf("Error: could only write %d bytes instead of %d\n", bytes_wrote, bytes_read);
+			exit_code = -1;
+			break;
+		}
+	}
+
+	return exit_code;
+}

--- a/util.h
+++ b/util.h
@@ -1,0 +1,6 @@
+#pragma once
+
+#include <stdio.h>
+#include "elmchan/src/ff.h"
+
+int write_file(FIL *image_fp, FILE *host_file);


### PR DESCRIPTION
Adds support for extracting files from a directory (non-recursive). Also adds MacOS support and some minor refactoring.

Examples:

`./fatboy TEST.FAT extractdir foo bar` will extract all files in `foo` on `TEST.FAT` to `bar` on the host machine.

`./fatboy TEST.FAT extractdir foo` will extract all files in `foo` on `TEST.FAT` to the current directory on the host machine.
